### PR TITLE
Makefile: Ensure files and directories exist when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,10 @@ tags:
 tarfile: veryclean
 	./mktarfile
 
-install: 
+install: eg
+	$(INSTALL) -d $(BINDIR)
 	$(INSTALL) eg $(BINDIR)
+	$(INSTALL) -d $(MANDIR)/man1
 	$(INSTALL) eg.1 $(MANDIR)/man1
 	$(INSTALL) -d $(NGDIR)
 	$(INSTALL) default-guide/eg.ng $(NGDIR)


### PR DESCRIPTION
This change ensures that:
1. `eg` is built before installing it.
2. All the parent directories are created if they don’t exist.
